### PR TITLE
fix: file name for router-outlet location to html

### DIFF
--- a/day-1/2-generating-components-and-nx-lib.md
+++ b/day-1/2-generating-components-and-nx-lib.md
@@ -72,7 +72,7 @@ export class AuthModule {}
 * Delete everything but the router-outlet on the apps app.component.html file
 
 {% code-tabs %}
-{% code-tabs-item title="apps/customer-portal/src/app.components.ts" %}
+{% code-tabs-item title="apps/customer-portal/src/app.components.html" %}
 ```typescript
 <router-outlet></router-outlet>
 ```


### PR DESCRIPTION
In section 2 when clearing out all of the html except the router-outlet, the file name was listed as app.components.ts instead of app.component.html