### PR TITLE
add: missing set/get/clear auth token methods

### DIFF
--- a/day-1/7-routing.md
+++ b/day-1/7-routing.md
@@ -303,6 +303,18 @@ export class AuthService {
         })
       );
   }
+  
+  setAuthToken(token: string) {
+    localStorage.setItem('token', token);
+  }
+
+  getAuthToken(): string {
+    return localStorage.getItem('token');
+  }
+
+  clearAuthToken() {
+    localStorage.removeItem('token');
+  }
 }
 ```
 {% endcode-tabs-item %}


### PR DESCRIPTION
the methods at https://github.com/duncanhunter/Demo-App-NDC-Minnesota-2018-Enterprise-Angular-applications-with-ngrx-and-nx/blob/part-7/libs/auth/src/services/auth/auth.service.ts#L26-L36 where not in the sample code for the lab.