### PR TITLE
Finished 12 and 13 update

### DIFF
--- a/12-ngrx-libs-and-action-creators.md
+++ b/12-ngrx-libs-and-action-creators.md
@@ -4,9 +4,12 @@ description: In this section we explore Strongly Typing the State and Actions
 
 # 12 - Strong Typing the State and Actions
 
+The [official docs](https://ngrx.io/guide/store/actions) say: *The createAction function returns a function, that when called returns an object in the shape of the Action interface. The props method is used to define any additional metadata needed for the handling of the action. Action creators provide a consistent, type-safe way to construct an action that is being dispatched.*
+
 ## 1. Add Login Action Creators
 
 {% code title="libs/auth/src/lib/+state/auth.actions.ts" %}
+
 ```typescript
 import { Action } from '@ngrx/store';
 import { Authenticate, User } from '@demo-app/data-models';
@@ -17,23 +20,22 @@ export enum AuthActionTypes {
   LoginFail = '[Auth API] Login Fail'
 }
 
-export class Login implements Action {
-  readonly type = AuthActionTypes.Login;
-  constructor(public payload: Authenticate) {}
-}
-export class LoginSuccess implements Action {
-  readonly type = AuthActionTypes.LoginSuccess;
-  constructor(public payload: User) {}
-}
+export const login = createAction(
+  AuthActionTypes.Login,
+  props<{ payload: Authenticate }> ()
+);
 
-export class LoginFail implements Action {
-  readonly type = AuthActionTypes.LoginFail;
-  constructor(public payload: any) {}
-}
+export const loginSuccess = createAction(
+  AuthActionTypes.LoginSuccess,
+  props<{ payload: User }>()
+);
 
-export type AuthActions = Login | LoginSuccess | LoginFail;
-
+export const loginFailure = createAction(
+  AuthActionTypes.LoginFail,
+  props<{ payload: any }>()
+);
 ```
+
 {% endcode %}
 
 ## Action Hygiene
@@ -54,9 +56,9 @@ Great presentation on Actions [https://www.youtube.com/watch?v=JmnsEvoy-gY&t=5s]
 * Update state interface
 
 {% code title="libs/auth/src/lib/+state/auth.reducer.ts" %}
+
 ```typescript
 //----- ABBREVIATED-----//
-
 
 /**
  * Interface for the 'Auth' data used in
@@ -79,7 +81,5 @@ export interface AuthState {
 
 //----- ABBREVIATED-----//
 ```
+
 {% endcode %}
-
-## 
-

--- a/14-ngrx-selectors.md
+++ b/14-ngrx-selectors.md
@@ -9,6 +9,7 @@ description: In this section we examine using selectors in NgRx.
 * Add a file called index.ts to the +state folder of your auth state lib
 
 {% code title="libs/auth/src/lib/+state/products.selectors.ts" %}
+
 ```typescript
 import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { ProductsState, ProductsData } from './products.reducer';
@@ -19,16 +20,20 @@ const getProductsState = createFeatureSelector<ProductsData>('products');
 const getProducts = createSelector(
   getProductsState,
   state => state.products
-);\export const productsQuery = {
+);
+
+export const productsQuery = {
   getProducts,
 };
 
 ```
+
 {% endcode %}
 
 * Ensure you have re-exported your publicly available paths in the auth libs index.ts file
 
 {% code title="libs/auth/index.ts" %}
+
 ```typescript
 export * from './lib/auth.module';
 export { AuthService } from './lib/services/auth/auth.service';
@@ -41,6 +46,7 @@ export * from './lib/+state';
 ## 2. Use selector in Layout component
 
 {% code title="libs/layout/src/lib/containers/layout/layout.component.ts" %}
+
 ```typescript
 import { Component, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
@@ -64,5 +70,5 @@ export class LayoutComponent implements OnInit {
 }
 
 ```
-{% endcode %}
 
+{% endcode %}

--- a/15-add-products-ngrx-feature-module.md
+++ b/15-add-products-ngrx-feature-module.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  In this section we challenge you understanding by adding a Products module
+  In this section we challenge your understanding by adding a Products module
   like we did for login
 ---
 


### PR DESCRIPTION
The old link for NgRx router-store navigation actions is a 404 now:

https://github.com/ngrx/platform/blob/master/docs/router-store/api.md#navigation-actions

I guess it is now one of these?

```txt
https://ngrx.io/api/router-store/RouterNavigationAction
https://ngrx.io/api/router-store
https://ngrx.io/guide/router-store/actions
```

I have chosen the last one unless you can find the current api page equivalent to what you linked to previously.